### PR TITLE
Fixes and improvements to enemy profiller

### DIFF
--- a/Assets/ForAndForeach/Scripts/Enemy/EnemyBehavior.cs
+++ b/Assets/ForAndForeach/Scripts/Enemy/EnemyBehavior.cs
@@ -66,5 +66,15 @@ namespace ForAndForeach
         {
             return _enemy.IsDead();
         }
+
+        public bool IsRanged()
+        {
+            return _enemy.Ranged;
+        }
+
+        public int GetAttack()
+        {
+            return _enemy.Attack;
+        }
     }
 }

--- a/Assets/ForAndForeach/Scripts/Execution/Execution.cs
+++ b/Assets/ForAndForeach/Scripts/Execution/Execution.cs
@@ -23,6 +23,7 @@ namespace ForAndForeach
                 EnemyExecution(ListCreator.GetEnemyList(10000));
 
                 FindFirstEnemy(EnemyManager.GetAllEnemies());
+                FirstDeadEnemy(EnemyManager.GetAllEnemies());
             }
         }
 
@@ -69,13 +70,16 @@ namespace ForAndForeach
         }
 
         private void FindFirstEnemy(List<EnemyBehavior> enemyList)
+        private void FirstDeadEnemy(List<EnemyBehavior> enemyList)
         {
             Profiler.BeginSample($"For And Foreach - For Enemy - First Enemy IsDead");
             for (int i = 0; i < enemyList.Count; i++)
             {
                 if (!enemyList[i].IsDead())
+                if (enemyList[i].IsDead())
                 {
                     Debug.Log($"Enemy Found {i}: {enemyList[i].ToString()}");
+                    break;
                 }
             }
             Profiler.EndSample();
@@ -84,8 +88,10 @@ namespace ForAndForeach
             foreach (EnemyBehavior enemy in enemyList)
             {
                 if (!enemy.IsDead())
+                if (enemy.IsDead())
                 {
                     Debug.Log($"Enemy Found: {enemy.ToString()}");
+                    break;
                 }
             }
             Profiler.EndSample();
@@ -109,6 +115,7 @@ namespace ForAndForeach
                     return;
                 }
             });
+            Debug.Log($"Enemy Found: {enemyList.FirstOrDefault(e => !e.IsDead())}");
             Profiler.EndSample();
         }
     }

--- a/Assets/ForAndForeach/Scripts/Execution/Execution.cs
+++ b/Assets/ForAndForeach/Scripts/Execution/Execution.cs
@@ -22,7 +22,6 @@ namespace ForAndForeach
                 EnemyExecution(ListCreator.GetEnemyList(1000));
                 EnemyExecution(ListCreator.GetEnemyList(10000));
 
-                FindFirstEnemy(EnemyManager.GetAllEnemies());
                 FirstDeadEnemy(EnemyManager.GetAllEnemies());
             }
         }
@@ -33,6 +32,7 @@ namespace ForAndForeach
             for (int i = 0; i < boolList.Count; i++)
             {
                 Debug.Log($"Value {boolList[i]}");
+                Debug.Log($"Value: {boolList[i]}");
             }
             Profiler.EndSample();
 
@@ -40,11 +40,13 @@ namespace ForAndForeach
             foreach (bool value in boolList)
             {
                 Debug.Log($"Value {value}");
+                Debug.Log($"Value: {value}");
             }
             Profiler.EndSample();
 
             Profiler.BeginSample($"For And Foreach - List.Foreach Bool - {boolList.Count}");
             boolList.ForEach(b => Debug.Log($"Value {b}"));
+            boolList.ForEach(v => Debug.Log($"Value {v}"));
             Profiler.EndSample();
         }
 
@@ -54,6 +56,7 @@ namespace ForAndForeach
             for (int i = 0; i < enemyList.Count; i++)
             {
                 Debug.Log(enemyList[i].ToString());
+                Debug.Log($"Value: {enemyList[i]}");
             }
             Profiler.EndSample();
 
@@ -61,61 +64,49 @@ namespace ForAndForeach
             foreach (Enemy enemy in enemyList)
             {
                 Debug.Log(enemy.ToString());
+                Debug.Log($"Value: {enemy}");
             }
             Profiler.EndSample();
 
             Profiler.BeginSample($"For And Foreach - Collections Enemy - {enemyList.Count}");
             enemyList.ForEach(e => Debug.Log($"Value {e.ToString()}"));
+            Profiler.BeginSample($"For And Foreach - List.Foreach Enemy - {enemyList.Count}");
+            enemyList.ForEach(e => Debug.Log($"Value {e}"));
             Profiler.EndSample();
         }
 
-        private void FindFirstEnemy(List<EnemyBehavior> enemyList)
         private void FirstDeadEnemy(List<EnemyBehavior> enemyList)
         {
             Profiler.BeginSample($"For And Foreach - For Enemy - First Enemy IsDead");
+            Profiler.BeginSample($"For And Foreach - For Enemy - First Dead Enemy");
             for (int i = 0; i < enemyList.Count; i++)
             {
-                if (!enemyList[i].IsDead())
                 if (enemyList[i].IsDead())
                 {
                     Debug.Log($"Enemy Found {i}: {enemyList[i].ToString()}");
+                    Debug.Log($"Enemy Found: {enemyList[i]}");
                     break;
                 }
             }
             Profiler.EndSample();
 
             Profiler.BeginSample($"For And Foreach - Foreach Enemy - First Enemy IsDead");
+            Profiler.BeginSample($"For And Foreach - Foreach Enemy - First Dead Enemy");
             foreach (EnemyBehavior enemy in enemyList)
             {
-                if (!enemy.IsDead())
                 if (enemy.IsDead())
                 {
                     Debug.Log($"Enemy Found: {enemy.ToString()}");
+                    Debug.Log($"Enemy Found: {enemy}");
                     break;
                 }
             }
             Profiler.EndSample();
 
-            ForeachEnemyCollections(enemyList);
-
             Profiler.BeginSample($"For And Foreach - Linq Enemy - First Enemy IsDead");
-            Debug.Log($"Enemy Found: {enemyList.Where(e => e.IsDead()).ToString()}");
-            Profiler.EndSample();
-        }
-
-        private void ForeachEnemyCollections(List<EnemyBehavior> enemyList)
-        {
-            Profiler.BeginSample($"For And Foreach - Foreach Collections Enemy - First Enemy IsDead");
-            enemyList.ForEach(e =>
-            {
-                if (e.IsDead())
-                {
-                    Debug.Log($"Enemy Found: {e.ToString()}");
-                    Profiler.EndSample();
-                    return;
-                }
-            });
             Debug.Log($"Enemy Found: {enemyList.FirstOrDefault(e => !e.IsDead())}");
+            Profiler.BeginSample($"For And Foreach - List.FirstOrDefault - First Dead Enemy");
+            Debug.Log($"Enemy Found: {enemyList.FirstOrDefault(e => e.IsDead())}");
             Profiler.EndSample();
         }
     }

--- a/Assets/ForAndForeach/Scripts/Execution/Execution.cs
+++ b/Assets/ForAndForeach/Scripts/Execution/Execution.cs
@@ -23,6 +23,7 @@ namespace ForAndForeach
                 EnemyExecution(ListCreator.GetEnemyList(10000));
 
                 FirstDeadEnemy(EnemyManager.GetAllEnemies());
+                AllDeadEnemies(EnemyManager.GetAllEnemies());
             }
         }
 
@@ -31,7 +32,6 @@ namespace ForAndForeach
             Profiler.BeginSample($"For And Foreach - For Bool - {boolList.Count}");
             for (int i = 0; i < boolList.Count; i++)
             {
-                Debug.Log($"Value {boolList[i]}");
                 Debug.Log($"Value: {boolList[i]}");
             }
             Profiler.EndSample();
@@ -39,13 +39,11 @@ namespace ForAndForeach
             Profiler.BeginSample($"For And Foreach - Foreach Bool - {boolList.Count}");
             foreach (bool value in boolList)
             {
-                Debug.Log($"Value {value}");
                 Debug.Log($"Value: {value}");
             }
             Profiler.EndSample();
 
             Profiler.BeginSample($"For And Foreach - List.Foreach Bool - {boolList.Count}");
-            boolList.ForEach(b => Debug.Log($"Value {b}"));
             boolList.ForEach(v => Debug.Log($"Value {v}"));
             Profiler.EndSample();
         }
@@ -55,7 +53,6 @@ namespace ForAndForeach
             Profiler.BeginSample($"For And Foreach - For Enemy - {enemyList.Count}");
             for (int i = 0; i < enemyList.Count; i++)
             {
-                Debug.Log(enemyList[i].ToString());
                 Debug.Log($"Value: {enemyList[i]}");
             }
             Profiler.EndSample();
@@ -63,13 +60,10 @@ namespace ForAndForeach
             Profiler.BeginSample($"For And Foreach - Foreach Enemy - {enemyList.Count}");
             foreach (Enemy enemy in enemyList)
             {
-                Debug.Log(enemy.ToString());
                 Debug.Log($"Value: {enemy}");
             }
             Profiler.EndSample();
 
-            Profiler.BeginSample($"For And Foreach - Collections Enemy - {enemyList.Count}");
-            enemyList.ForEach(e => Debug.Log($"Value {e.ToString()}"));
             Profiler.BeginSample($"For And Foreach - List.Foreach Enemy - {enemyList.Count}");
             enemyList.ForEach(e => Debug.Log($"Value {e}"));
             Profiler.EndSample();
@@ -77,36 +71,70 @@ namespace ForAndForeach
 
         private void FirstDeadEnemy(List<EnemyBehavior> enemyList)
         {
-            Profiler.BeginSample($"For And Foreach - For Enemy - First Enemy IsDead");
             Profiler.BeginSample($"For And Foreach - For Enemy - First Dead Enemy");
             for (int i = 0; i < enemyList.Count; i++)
             {
                 if (enemyList[i].IsDead())
                 {
-                    Debug.Log($"Enemy Found {i}: {enemyList[i].ToString()}");
                     Debug.Log($"Enemy Found: {enemyList[i]}");
                     break;
                 }
             }
             Profiler.EndSample();
 
-            Profiler.BeginSample($"For And Foreach - Foreach Enemy - First Enemy IsDead");
             Profiler.BeginSample($"For And Foreach - Foreach Enemy - First Dead Enemy");
             foreach (EnemyBehavior enemy in enemyList)
             {
                 if (enemy.IsDead())
                 {
-                    Debug.Log($"Enemy Found: {enemy.ToString()}");
                     Debug.Log($"Enemy Found: {enemy}");
                     break;
                 }
             }
             Profiler.EndSample();
 
-            Profiler.BeginSample($"For And Foreach - Linq Enemy - First Enemy IsDead");
-            Debug.Log($"Enemy Found: {enemyList.FirstOrDefault(e => !e.IsDead())}");
             Profiler.BeginSample($"For And Foreach - List.FirstOrDefault - First Dead Enemy");
             Debug.Log($"Enemy Found: {enemyList.FirstOrDefault(e => e.IsDead())}");
+            Profiler.EndSample();
+        }
+
+        private void AllDeadEnemies(List<EnemyBehavior> enemyList)
+        {
+            Profiler.BeginSample($"For And Foreach - For Enemy - All Dead Enemies");
+            for (int i = 0; i < enemyList.Count; i++)
+            {
+                if (enemyList[i].IsDead())
+                {
+                    Debug.Log($"Enemy Found: {enemyList[i]}");
+                }
+            }
+            Profiler.EndSample();
+
+            Profiler.BeginSample($"For And Foreach - Foreach Enemy - All Dead Enemies");
+            foreach (EnemyBehavior enemy in enemyList)
+            {
+                if (enemy.IsDead())
+                {
+                    Debug.Log($"Enemy Found: {enemy}");
+                }
+            }
+            Profiler.EndSample();
+
+            Profiler.BeginSample($"For And Foreach - List.Foreach Enemy - All Dead Enemies");
+            enemyList.ForEach(e =>
+            {
+                if (e.IsDead())
+                {
+                    Debug.Log($"Enemy Found: {e}");                    
+                }
+            });
+            Profiler.EndSample();
+
+            Profiler.BeginSample($"For And Foreach - List.Where.ToList.ForEach Enemy - All Dead Enemies");
+            enemyList.Where(e => e.IsDead()).ToList().ForEach(e =>
+            {
+                Debug.Log($"Enemy Found: {e}");
+            });
             Profiler.EndSample();
         }
     }

--- a/Assets/ForAndForeach/Scripts/Execution/Execution.cs
+++ b/Assets/ForAndForeach/Scripts/Execution/Execution.cs
@@ -24,6 +24,7 @@ namespace ForAndForeach
 
                 FirstDeadEnemy(EnemyManager.GetAllEnemies());
                 AllDeadEnemies(EnemyManager.GetAllEnemies());
+                ComplexEnemyTest(EnemyManager.GetAllEnemies());
             }
         }
 
@@ -135,6 +136,37 @@ namespace ForAndForeach
             {
                 Debug.Log($"Enemy Found: {e}");
             });
+            Profiler.EndSample();
+        }
+
+        private void ComplexEnemyTest(List<EnemyBehavior> enemyList)
+        {
+            // Sum all attack from live ranged enemies
+
+            Profiler.BeginSample($"For And Foreach - For Enemy - Complex Enemy");
+            int totalAttack = 0;
+            for (int i = 0; i < enemyList.Count; i++)
+            {
+                if (!enemyList[i].IsDead() && enemyList[i].IsRanged())
+                {
+                    totalAttack += enemyList[i].GetAttack();
+                }
+            }
+            Profiler.EndSample();
+
+            Profiler.BeginSample($"For And Foreach - Foreach Enemy - Complex Enemy");
+            totalAttack = 0;
+            foreach (EnemyBehavior enemy in enemyList)
+            {
+                if (!enemy.IsDead() && enemy.IsRanged())
+                {
+                    totalAttack += enemy.GetAttack();
+                }
+            }
+            Profiler.EndSample();
+
+            Profiler.BeginSample($"For And Foreach - List.FirstOrDefault - Complex Enemy");
+            enemyList.Where(e => !e.IsDead() && e.IsRanged()).Sum(e => e.GetAttack());
             Profiler.EndSample();
         }
     }


### PR DESCRIPTION
- Fixed misbehavior for 'find the first enemy' where loops were not breaking on the first enemy found. Making wong profiler results.
- Also changed some names and strings for better readability.
- Added two new profiler options to check Linq performance.